### PR TITLE
update book introduction links

### DIFF
--- a/chapters/01-introduction-ebook.md
+++ b/chapters/01-introduction-ebook.md
@@ -10,9 +10,6 @@ To view a copy of this license, visit
 This book is open source:
 <https://github.com/semaphoreci/book-cicd-docker-kubernetes>
 
-Published on the Semaphore website:
-[https://semaphoreci.com](https://semaphoreci.com/?utm_source=ebook&utm_medium=pdf&utm_campaign=cicd-docker-kubernetes-semaphore)
-
 $MONTHYEAR: First edition v1.1 (revision $REVISION)
 
 \newpage


### PR DESCRIPTION
Removes "Published on the Semaphore website: https://semaphoreci.com" from the introduction chapter for the ebook.
