### PR TITLE
feat: upload EPUB & MOBI too

### DIFF
--- a/.semaphore/pipeline_2.yml
+++ b/.semaphore/pipeline_2.yml
@@ -12,5 +12,13 @@ blocks:
           commands:
             - artifact pull workflow CICD_with_Docker_Kubernetes_Semaphore.pdf
             - 'echo "put CICD_with_Docker_Kubernetes_Semaphore.pdf" | sshpass -p "$FTP_PASSWORD" sftp -P $FTP_PORT -o StrictHostKeyChecking=no $FTP_USER@$FTP_HOST:/wp-content/uploads/2020/05/'
+        - name: Upload EPUB
+          commands:
+            - artifact pull workflow CICD_with_Docker_Kubernetes_Semaphore.epub
+            - 'echo "put CICD_with_Docker_Kubernetes_Semaphore.epub" | sshpass -p "$FTP_PASSWORD" sftp -P $FTP_PORT -o StrictHostKeyChecking=no $FTP_USER@$FTP_HOST:/wp-content/uploads/2020/05/'
+        - name: Upload MOBI
+          commands:
+            - artifact pull workflow CICD_with_Docker_Kubernetes_Semaphore.mobi
+            - 'echo "put CICD_with_Docker_Kubernetes_Semaphore.mobi" | sshpass -p "$FTP_PASSWORD" sftp -P $FTP_PORT -o StrictHostKeyChecking=no $FTP_USER@$FTP_HOST:/wp-content/uploads/2020/05/'
       secrets:
         - name: wordpress-sftp


### PR DESCRIPTION
CI/CD workflow should upload all generated artifacts. 

Download webpage talks about book also exists in EPUB & MOBI formats.

So... add to promoted pipeline two more task in charge to upload both files, assuming same folder where PDF is hosted.

Improves semaphoreci/book-cicd-docker-kubernetes#10 (https://github.com/semaphoreci/book-cicd-docker-kubernetes/pull/10/commits/8e9d839e3833ec429870c22aa576c51859fbc145) adding semaphoreci/book-cicd-docker-kubernetes#6 build task